### PR TITLE
Actions: change jungwinter/split@v1 to winterjung/split@v2, due to the owner renaming its username

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -161,7 +161,7 @@ jobs:
         id: split
         with:
           msg: ${{ github.ref }}
-          seperator: /
+          separator: /
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
@@ -191,7 +191,7 @@ jobs:
         id: split
         with:
           msg: ${{ github.ref }}
-          seperator: /
+          separator: /
       - name: Get release
         id: get_release_info
         uses: leahlundqvist/get-release@v1.3.1

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get short tag name
-        uses: jungwinter/split@v1
+        uses: winterjung/split@v2
         id: split
         with:
           msg: ${{ github.ref }}
@@ -187,7 +187,7 @@ jobs:
           name: ${{ matrix.version }}
           path: ./${{ matrix.version }}
       - name: Get short tag name
-        uses: jungwinter/split@v1
+        uses: winterjung/split@v2
         id: split
         with:
           msg: ${{ github.ref }}


### PR DESCRIPTION
See https://github.com/vlang/v/pull/21073 and https://github.com/winterjung/split/issues/23 .